### PR TITLE
WHMCS-Bridge Footer Fix

### DIFF
--- a/orderforms/bootorder/configureproductdomain.tpl
+++ b/orderforms/bootorder/configureproductdomain.tpl
@@ -228,3 +228,4 @@ function completedomain() {
 }
 </script>
 {/literal}
+{include file="orderforms/$carttpl/footer.tpl" title=$productinfo.name}


### PR DESCRIPTION
Stops WHMCS-Bridge from shrinking the rest of footer on site.  
Thanks to Nathan Oertel from Digital Cloud Designs for fix.